### PR TITLE
feat(entities): Introduce Message entity and update Room and User rel…

### DIFF
--- a/src/modules/chat/chat.gateway.ts
+++ b/src/modules/chat/chat.gateway.ts
@@ -24,6 +24,7 @@ import { plainToInstance } from 'class-transformer';
 import { User } from '../user/entities/user.entity';
 import { UpdateRoomDto } from './dtos/room/update-room.dto';
 import { DeleteRoomDto } from './dtos/room/delete-room.dto';
+import { CreateMessageDto } from './dtos/message/create-message.dto';
 
 @UseFilters(WsExceptionFilter)
 @WebSocketGateway(4800, { cors: { origin: '*' } })
@@ -244,6 +245,13 @@ export class ChatGateway
       },
     );
   }
+
+  @SubscribeMessage('sendMessage')
+  async onSendMessage(
+    @WsCurrentUser() currentUser: UserPayload,
+    @MessageBody() createMessageDto: CreateMessageDto,
+    @ConnectedSocket() socket: Socket,
+  ): Promise<void> {}
 
   private async fetchParticipants(participantsIds: string[]): Promise<User[]> {
     const participants: User[] = [];

--- a/src/modules/chat/dtos/message/create-message.dto.ts
+++ b/src/modules/chat/dtos/message/create-message.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateMessageDto {
+  @ApiProperty({ required: true })
+  @IsString()
+  @IsNotEmpty()
+  roomId: number;
+
+  @ApiProperty({ required: true })
+  @IsString()
+  @IsNotEmpty()
+  text: string;
+}

--- a/src/modules/chat/entities/message.entity.ts
+++ b/src/modules/chat/entities/message.entity.ts
@@ -1,0 +1,20 @@
+import { BaseEntity } from 'src/common/entities/base.entity';
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { Room } from './room.entity';
+import { User } from 'src/modules/user/entities/user.entity';
+
+@Entity({ name: 'message' })
+export class Message extends BaseEntity {
+  @Column()
+  roomId: number;
+
+  @Column()
+  text: string;
+
+  @ManyToOne(() => Room, (roomEntity) => roomEntity.messages)
+  room: Room;
+
+  @ManyToOne(() => User, (user) => user.messages)
+  @JoinColumn([{ name: 'createdBy', referencedColumnName: 'id' }])
+  creator: User;
+}

--- a/src/modules/chat/entities/room.entity.ts
+++ b/src/modules/chat/entities/room.entity.ts
@@ -1,6 +1,14 @@
 import { BaseEntity } from 'src/common/entities/base.entity';
-import { Entity, Column, Unique, ManyToMany, JoinTable } from 'typeorm';
+import {
+  Entity,
+  Column,
+  Unique,
+  ManyToMany,
+  JoinTable,
+  OneToMany,
+} from 'typeorm';
 import { User } from '../../user/entities/user.entity';
+import { Message } from './message.entity';
 
 @Entity({ name: 'room' })
 @Unique(['name'])
@@ -20,4 +28,7 @@ export class Room extends BaseEntity {
 
   @Column()
   updatedBy: string;
+
+  @OneToMany(() => Message, (message) => message.room)
+  messages: Message[];
 }

--- a/src/modules/chat/services/message.service.ts
+++ b/src/modules/chat/services/message.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Message } from '../entities/message.entity';
+import { CreateMessageDto } from '../dtos/message/create-message.dto';
+
+@Injectable()
+export class MessageService {
+  constructor(
+    @InjectRepository(Message)
+    private readonly messageRepository: Repository<Message>,
+  ) {}
+
+  async create(userId: string, createMessageDto: CreateMessageDto) {}
+}

--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -2,6 +2,7 @@ import { Room } from 'src/modules/chat/entities/room.entity';
 import { BaseEntity } from 'src/common/entities/base.entity';
 import { Column, Entity, ManyToMany, OneToMany, Unique } from 'typeorm';
 import { ConnectedUser } from 'src/modules/chat/entities/connected-user.entity';
+import { Message } from 'src/modules/chat/entities/message.entity';
 
 @Entity({ name: 'user' })
 @Unique(['email'])
@@ -26,4 +27,7 @@ export class User extends BaseEntity {
 
   @OneToMany(() => ConnectedUser, (connectedUser) => connectedUser.user)
   connectedUsers: ConnectedUser[];
+
+  @OneToMany(() => Message, (message) => message.creator)
+  messages: Message[];
 }


### PR DESCRIPTION
…ations

- Added the Message entity to represent chat messages within rooms. Each message is linked to a specific Room and a User (as the creator) via many-to-one relationships.
- Updated the Room entity to include a one-to-many relationship with Message, allowing rooms to contain multiple messages.
- Enhanced the User entity to establish a one-to-many relationship with Message, enabling users to be associated with the messages they create.
- Ensured that all entity relationships are reciprocal and properly annotated with TypeORM decorators for accurate ORM mapping and database integrity.

This update lays the foundational structure for handling chat messages in the application, facilitating message tracking within rooms and by users.